### PR TITLE
Remove non-existent packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ chardet==3.0.4
 cymem==2.0.2
 cytoolz==0.9.0.1
 dill==0.2.8.2
-en-core-web-sm==2.0.0
 fasttext==0.8.22
 fuzzywuzzy==0.17.0
 idna==2.7
@@ -12,7 +11,6 @@ msgpack==0.5.6
 msgpack-numpy==0.4.3.2
 murmurhash==1.0.1
 numpy==1.15.3
-pkg-resources==0.0.0
 plac==0.9.6
 preshed==2.0.1
 pybind11==2.2.4


### PR DESCRIPTION
Microsoft security has asked us to remove these two packages (which no longer exist) from requirements.txt, because an attacker could conceivably create a malicious pypi package under either name. Then if a user did `pip install -r requirements`, the malicious package would be installed, and upon invocation could take control of the user's computer. (Note that requirements.txt is not part of the recommended nail_agent installation process; it's only provided for reference.)